### PR TITLE
Add dropdown options and CORS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# California Scratch Ticket Expected Value Calculator
+
+This repository contains a simple web page that estimates the expected value of a California Lottery scratch ticket. A few popular scratchers are available from a dropdown, or you can paste any scratcher URL. The script parses the ticket information and calculates the expected value based on the remaining prizes table.
+
+To use it:
+
+1. Open `index.html` in a modern browser (or host the repository with GitHub Pages).
+2. Select a scratcher from the dropdown or paste a URL in the input field.
+3. Click **Calculate**.
+
+The script scrapes the prize table and other details using XPath selectors similar to those used with `IMPORTXML` in Google Sheets. It then computes an estimated expected value by scaling the number of non‑winning tickets according to the ratio of remaining winning tickets.
+
+**Note:** This tool relies on the structure of the California Lottery website. If the site's HTML changes or if cross-origin requests are blocked, the script may not work without adjustments.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Scratch Ticket EV</title>
+<style>
+  body { font-family: Arial, sans-serif; margin: 2em; }
+  input[type=text] { width: 400px; }
+  #results { margin-top: 2em; white-space: pre-wrap; }
+</style>
+</head>
+<body>
+<h1>California Scratch Ticket Expected Value</h1>
+<label for="ticketSelect">Choose a scratcher: </label>
+<select id="ticketSelect">
+  <option value="https://www.calottery.com/en/scratchers/$3/california-crossword-1676">California Crossword (1676)</option>
+  <option value="https://www.calottery.com/en/scratchers/$3/loteria-1666">Loteria (1666)</option>
+</select>
+<br/><br/>
+<label>Ticket URL: <input id="ticketUrl" type="text" placeholder="https://www.calottery.com/..." /></label>
+<button id="calc">Calculate</button>
+<div id="results"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,69 @@
+async function fetchTicket() {
+  const url = document.getElementById('ticketUrl').value.trim();
+  if (!url) return;
+  document.getElementById('results').textContent = 'Loading...';
+  try {
+    const res = await fetch('https://corsproxy.io/?' + encodeURIComponent(url));
+    if (!res.ok) throw new Error('Fetch failed');
+    const html = await res.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+
+    const xp = (path) => doc.evaluate(path, doc, null, XPathResult.STRING_TYPE, null).stringValue.trim();
+
+    const data = {};
+    data.name = xp('/html/head/title');
+    data.cost = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Price") or contains(text(),"Cost")]/strong');
+    data.gameNumber = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Game")]/strong');
+    data.overallOdds = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Overall Odds")]/strong');
+    data.cashOdds = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Cash Odds")]/strong');
+
+    const base = '//*[@id="section-content-1-3"]/div/div[2]/table/tbody';
+    const prizes = [];
+    for (let i = 2; i <= 11; i++) {
+      const prize = xp(`${base}/tr[${i}]/td[1]`);
+      if (!prize) break;
+      const odds = xp(`${base}/tr[${i}]/td[2]`);
+      const remaining = xp(`${base}/tr[${i}]/td[3]/span[1]`);
+      const initial = xp(`${base}/tr[${i}]/td[3]/span[2]`);
+      prizes.push({prize, odds, remaining, initial});
+    }
+
+    const num = (s) => parseFloat((s||'0').replace(/[^0-9.]+/g, '')) || 0;
+    const ticketCost = num(data.cost);
+
+    let initialWinning = 0, currentWinning = 0;
+    prizes.forEach(p => {
+      p.value = /ticket/i.test(p.prize) ? ticketCost : num(p.prize);
+      p.remaining = num(p.remaining);
+      p.initial = num(p.initial);
+      initialWinning += p.initial;
+      currentWinning += p.remaining;
+    });
+
+    const overall = parseFloat((data.overallOdds.match(/[0-9.]+/)||['0'])[0]);
+    const totalInitial = initialWinning * overall;
+    const initialLosing = totalInitial - initialWinning;
+    const currentLosing = initialLosing * (currentWinning / initialWinning);
+    const totalRemaining = currentWinning + currentLosing;
+
+    let evPrize = 0;
+    prizes.forEach(p => { evPrize += (p.remaining / totalRemaining) * p.value; });
+
+    data.expectedValue = (evPrize - ticketCost).toFixed(4);
+    let out = `Name: ${data.name}\nCost: ${data.cost}\nGame Number: ${data.gameNumber}\nOverall Odds: ${data.overallOdds}\nCash Odds: ${data.cashOdds}\nExpected Ticket Value: ${data.expectedValue}`;
+    document.getElementById('results').textContent = out;
+  } catch (err) {
+    document.getElementById('results').textContent = 'Error: ' + err.message;
+  }
+}
+
+document.getElementById('calc').addEventListener('click', fetchTicket);
+const select = document.getElementById('ticketSelect');
+if (select) {
+  const input = document.getElementById('ticketUrl');
+  input.value = select.value;
+  select.addEventListener('change', () => {
+    input.value = select.value;
+  });
+}


### PR DESCRIPTION
## Summary
- add a dropdown with example scratchers in `index.html`
- use a CORS proxy when fetching ticket data
- sync dropdown and text input values
- update README with the new workflow

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841f6910cb0832dbab1d092c3190638