### PR TITLE
Add debug page for proxy fetch diagnostics and improve UI/error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,23 @@
 
 This repository contains a simple web page that estimates the expected value of a California Lottery scratch ticket. A few popular scratchers are available from a dropdown, or you can paste any scratcher URL. The script parses the ticket information and calculates the expected value based on the remaining prizes table.
 
-To use it:
+## Live site (GitHub Pages)
+
+After enabling GitHub Pages for this repository (Settings → Pages → Deploy from `main`/`master` + `/root`), the site is available at:
+
+`https://frankmdmc.github.io/CodexDidThis/`
+
+## Local usage
 
 1. Open `index.html` in a modern browser (or host the repository with GitHub Pages).
 2. Select a scratcher from the dropdown or paste a URL in the input field.
-
 3. Click **Calculate**.
+
+If you see a "Fetch failed" error on the live site, open `debug.html` and run the diagnostics.
+Share the output so we can identify which proxy is failing.
 
 The script scrapes the prize table and other details using XPath selectors similar to those used with `IMPORTXML` in Google Sheets. It then computes an estimated expected value by scaling the number of non‑winning tickets according to the ratio of remaining winning tickets.
 
 **Note:** This tool relies on the structure of the California Lottery website. If the site's HTML changes or if cross-origin requests are blocked, the script may not work without adjustments.
 To avoid cross-origin restrictions, the page fetches scratcher URLs through the
 public `api.allorigins.win` proxy.
-

--- a/debug.html
+++ b/debug.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Scratch Ticket Fetch Debug</title>
+<style>
+  body { font-family: Arial, sans-serif; margin: 2em; background: #f6f6f6; color: #222; }
+  main { max-width: 880px; margin: 0 auto; background: #fff; padding: 2rem; border-radius: 12px; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06); }
+  label { font-weight: 600; display: block; margin-top: 1rem; }
+  input[type=text] { width: 100%; max-width: 560px; padding: 0.5rem; border-radius: 6px; border: 1px solid #ccc; }
+  button { margin-top: 1rem; padding: 0.6rem 1.2rem; border-radius: 6px; border: none; background: #1b6ef3; color: #fff; font-weight: 600; cursor: pointer; }
+  button:disabled { opacity: 0.6; cursor: not-allowed; }
+  pre { margin-top: 1.5rem; background: #0b1b33; color: #f4f6fb; padding: 1rem; border-radius: 8px; white-space: pre-wrap; }
+  .helper { color: #555; font-size: 0.95rem; }
+  a { color: #1b6ef3; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Scratch Ticket Fetch Debug</h1>
+  <p class="helper">
+    This page runs verbose diagnostics for the proxy fetches used by the main app.
+    Paste the results back into the issue so we can see which proxy (if any) is failing.
+  </p>
+  <label for="debugUrl">Ticket URL</label>
+  <input id="debugUrl" type="text" placeholder="https://www.calottery.com/..." />
+  <button id="runDebug" type="button">Run Diagnostics</button>
+  <pre id="debugOutput">Waiting for input...</pre>
+  <p class="helper">
+    Return to the <a href="index.html">main calculator</a>.
+  </p>
+</main>
+<script src="debug.js"></script>
+</body>
+</html>

--- a/debug.js
+++ b/debug.js
@@ -1,0 +1,93 @@
+const output = document.getElementById('debugOutput');
+const debugButton = document.getElementById('runDebug');
+const urlInput = document.getElementById('debugUrl');
+
+const proxies = [
+  {
+    name: 'allorigins raw',
+    buildUrl: (url) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`,
+  },
+  {
+    name: 'allorigins get',
+    buildUrl: (url) => `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`,
+    parse: (text) => {
+      try {
+        const data = JSON.parse(text);
+        return {
+          content: data.contents || '',
+          warning: data.status?.http_code ? `HTTP ${data.status.http_code}` : '',
+        };
+      } catch (error) {
+        return { content: text, warning: `JSON parse error: ${error.message}` };
+      }
+    },
+  },
+  {
+    name: 'r.jina.ai',
+    buildUrl: (url) => `https://r.jina.ai/http://r.jina.ai/http://${url.replace(/^https?:\/\//, '')}`,
+  },
+];
+
+const formatLine = (label, value) => `${label}: ${value ?? 'n/a'}`;
+
+const runFetch = async (targetUrl, proxy) => {
+  const start = performance.now();
+  const response = await fetch(proxy.buildUrl(targetUrl));
+  const duration = Math.round(performance.now() - start);
+  const text = await response.text();
+  const parsed = proxy.parse ? proxy.parse(text) : { content: text, warning: '' };
+  const content = parsed.content || '';
+  const snippet = content.slice(0, 500).replace(/\s+/g, ' ');
+  return {
+    name: proxy.name,
+    url: proxy.buildUrl(targetUrl),
+    ok: response.ok,
+    status: response.status,
+    duration,
+    contentType: response.headers.get('content-type'),
+    snippet: snippet || '(empty response)',
+    warning: parsed.warning,
+  };
+};
+
+const runDiagnostics = async () => {
+  const targetUrl = urlInput.value.trim();
+  output.textContent = '';
+  if (!targetUrl) {
+    output.textContent = 'Paste a scratcher URL before running diagnostics.';
+    return;
+  }
+  try {
+    new URL(targetUrl);
+  } catch {
+    output.textContent = 'That does not look like a valid URL.';
+    return;
+  }
+
+  debugButton.disabled = true;
+  output.textContent = `Running diagnostics for: ${targetUrl}\n`;
+  for (const proxy of proxies) {
+    output.textContent += `\n=== ${proxy.name} ===\n`;
+    output.textContent += `${formatLine('Proxy URL', proxy.buildUrl(targetUrl))}\n`;
+    try {
+      const result = await runFetch(targetUrl, proxy);
+      output.textContent += `${formatLine('HTTP status', `${result.status} (${result.ok ? 'ok' : 'not ok'})`)}\n`;
+      output.textContent += `${formatLine('Duration', `${result.duration}ms`)}\n`;
+      output.textContent += `${formatLine('Content-Type', result.contentType)}\n`;
+      if (result.warning) {
+        output.textContent += `${formatLine('Warning', result.warning)}\n`;
+      }
+      output.textContent += `${formatLine('Snippet', result.snippet)}\n`;
+    } catch (error) {
+      output.textContent += `${formatLine('Error', error.message)}\n`;
+    }
+  }
+  debugButton.disabled = false;
+};
+
+debugButton.addEventListener('click', runDiagnostics);
+urlInput.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    runDiagnostics();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -4,23 +4,38 @@
 <meta charset="UTF-8">
 <title>Scratch Ticket EV</title>
 <style>
-  body { font-family: Arial, sans-serif; margin: 2em; }
-  input[type=text] { width: 400px; }
-  #results { margin-top: 2em; white-space: pre-wrap; }
+  body { font-family: Arial, sans-serif; margin: 2em; background: #f6f6f6; color: #222; }
+  main { max-width: 880px; margin: 0 auto; background: #fff; padding: 2rem; border-radius: 12px; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06); }
+  label { font-weight: 600; display: block; margin-top: 1rem; }
+  input[type=text], select { width: 100%; max-width: 520px; padding: 0.5rem; border-radius: 6px; border: 1px solid #ccc; }
+  button { margin-top: 1rem; padding: 0.6rem 1.2rem; border-radius: 6px; border: none; background: #1b6ef3; color: #fff; font-weight: 600; cursor: pointer; }
+  button:disabled { opacity: 0.6; cursor: not-allowed; }
+  #results { margin-top: 1.5rem; white-space: pre-wrap; background: #0b1b33; color: #f4f6fb; padding: 1rem; border-radius: 8px; }
+  #status { margin-top: 0.75rem; color: #c45500; font-weight: 600; }
+  .helper { color: #555; font-size: 0.95rem; }
 </style>
 </head>
 <body>
-<h1>California Scratch Ticket Expected Value</h1>
-<label for="ticketSelect">Choose a scratcher: </label>
-<select id="ticketSelect">
-  <option value="https://www.calottery.com/en/scratchers/$3/california-crossword-1676">California Crossword (1676)</option>
-  <option value="https://www.calottery.com/en/scratchers/$3/loteria-1666">Loteria (1666)</option>
-</select>
-<br/><br/>
+<main>
+  <h1>California Scratch Ticket Expected Value</h1>
+  <p class="helper">Pick a known scratcher or paste any California Lottery scratcher URL to estimate expected ticket value from the remaining prizes table.</p>
+  <label for="ticketSelect">Choose a scratcher</label>
+  <select id="ticketSelect">
+    <option value="https://www.calottery.com/en/scratchers/$3/california-crossword-1676">California Crossword (1676)</option>
+    <option value="https://www.calottery.com/en/scratchers/$3/loteria-1666">Loteria (1666)</option>
+  </select>
 
-<label>Ticket URL: <input id="ticketUrl" type="text" placeholder="https://www.calottery.com/..." /></label>
-<button id="calc">Calculate</button>
-<div id="results"></div>
+  <label for="ticketUrl">Ticket URL</label>
+  <input id="ticketUrl" type="text" placeholder="https://www.calottery.com/..." />
+  <button id="calc" type="button">Calculate</button>
+  <div id="status" role="status" aria-live="polite"></div>
+  <div id="results" aria-live="polite"></div>
+  <p class="helper">
+    Seeing "Fetch failed"? Use the
+    <a href="debug.html">debug page</a>
+    to capture diagnostics for the proxy fetches.
+  </p>
+</main>
 <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,43 +1,99 @@
-async function fetchTicket() {
-  const url = document.getElementById('ticketUrl').value.trim();
-  if (!url) return;
-  document.getElementById('results').textContent = 'Loading...';
-  try {
-    // use a public CORS proxy so the browser can fetch the ticket page
-    // `allorigins` expects the target URL in the `url` query parameter
-    const proxyUrl = 'https://api.allorigins.win/raw?url=' + encodeURIComponent(url);
-    const res = await fetch(proxyUrl);
+const results = document.getElementById('results');
+const statusMessage = document.getElementById('status');
+const calcButton = document.getElementById('calc');
+const input = document.getElementById('ticketUrl');
+const select = document.getElementById('ticketSelect');
 
-    if (!res.ok) throw new Error('Fetch failed');
-    const html = await res.text();
+const setStatus = (message = '') => {
+  statusMessage.textContent = message;
+};
+
+const setLoading = (loading) => {
+  calcButton.disabled = loading;
+  if (loading) {
+    results.textContent = '';
+    setStatus('Loading ticket data...');
+  }
+};
+
+const fetchTicketHtml = async (url) => {
+  const proxyUrl = 'https://api.allorigins.win/raw?url=' + encodeURIComponent(url);
+  const res = await fetch(proxyUrl);
+  if (!res.ok) {
+    throw new Error('Fetch failed. The proxy might be unavailable.');
+  }
+  return res.text();
+};
+
+const textFromCell = (cell) => (cell ? cell.textContent.trim() : '');
+
+const parsePrizeCounts = (cell) => {
+  if (!cell) return { remaining: '', initial: '' };
+  const spans = cell.querySelectorAll('span');
+  if (spans.length >= 2) {
+    return {
+      remaining: spans[0].textContent.trim(),
+      initial: spans[1].textContent.trim(),
+    };
+  }
+  const parts = cell.textContent.split(/\s+/).filter(Boolean);
+  return { remaining: parts[0] || '', initial: parts[1] || '' };
+};
+
+async function fetchTicket() {
+  const url = input.value.trim();
+  results.textContent = '';
+  setStatus('');
+  if (!url) {
+    setStatus('Paste a valid California Lottery scratcher URL.');
+    return;
+  }
+  try {
+    new URL(url);
+  } catch {
+    setStatus('That URL does not look valid. Please double-check it.');
+    return;
+  }
+
+  try {
+    setLoading(true);
+    const html = await fetchTicketHtml(url);
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, 'text/html');
 
     const xp = (path) => doc.evaluate(path, doc, null, XPathResult.STRING_TYPE, null).stringValue.trim();
-
     const data = {};
-    data.name = xp('/html/head/title');
+    data.name = xp('/html/head/title') || 'Unknown ticket';
     data.cost = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Price") or contains(text(),"Cost")]/strong');
     data.gameNumber = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Game")]/strong');
     data.overallOdds = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Overall Odds")]/strong');
     data.cashOdds = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Cash Odds")]/strong');
 
-    const base = '//*[@id="section-content-1-3"]/div/div[2]/table/tbody';
     const prizes = [];
-    for (let i = 2; i <= 11; i++) {
-      const prize = xp(`${base}/tr[${i}]/td[1]`);
-      if (!prize) break;
-      const odds = xp(`${base}/tr[${i}]/td[2]`);
-      const remaining = xp(`${base}/tr[${i}]/td[3]/span[1]`);
-      const initial = xp(`${base}/tr[${i}]/td[3]/span[2]`);
-      prizes.push({prize, odds, remaining, initial});
+    const rows = doc.querySelectorAll('#section-content-1-3 table tbody tr');
+    rows.forEach((row, index) => {
+      if (index === 0) return;
+      const cells = row.querySelectorAll('td');
+      if (cells.length < 3) return;
+      const { remaining, initial } = parsePrizeCounts(cells[2]);
+      prizes.push({
+        prize: textFromCell(cells[0]),
+        odds: textFromCell(cells[1]),
+        remaining,
+        initial,
+      });
+    });
+
+    if (!prizes.length) {
+      throw new Error('No prize table found. The page layout may have changed.');
     }
 
-    const num = (s) => parseFloat((s||'0').replace(/[^0-9.]+/g, '')) || 0;
+    const num = (s) => parseFloat((s || '0').replace(/[^0-9.]+/g, '')) || 0;
     const ticketCost = num(data.cost);
 
-    let initialWinning = 0, currentWinning = 0;
-    prizes.forEach(p => {
+    let initialWinning = 0;
+    let currentWinning = 0;
+    prizes.forEach((p) => {
       p.value = /ticket/i.test(p.prize) ? ticketCost : num(p.prize);
       p.remaining = num(p.remaining);
       p.initial = num(p.initial);
@@ -45,27 +101,47 @@ async function fetchTicket() {
       currentWinning += p.remaining;
     });
 
-    const overall = parseFloat((data.overallOdds.match(/[0-9.]+/)||['0'])[0]);
+    if (!initialWinning) {
+      throw new Error('Could not calculate remaining prizes. Missing prize counts.');
+    }
+
+    const overall = parseFloat((data.overallOdds.match(/[0-9.]+/) || ['0'])[0]);
+    if (!overall) {
+      throw new Error('Overall odds were not found. The ticket page may have changed.');
+    }
     const totalInitial = initialWinning * overall;
     const initialLosing = totalInitial - initialWinning;
     const currentLosing = initialLosing * (currentWinning / initialWinning);
     const totalRemaining = currentWinning + currentLosing;
+    if (!totalRemaining) {
+      throw new Error('Could not calculate remaining ticket totals.');
+    }
 
     let evPrize = 0;
-    prizes.forEach(p => { evPrize += (p.remaining / totalRemaining) * p.value; });
+    prizes.forEach((p) => {
+      evPrize += (p.remaining / totalRemaining) * p.value;
+    });
 
     data.expectedValue = (evPrize - ticketCost).toFixed(4);
-    let out = `Name: ${data.name}\nCost: ${data.cost}\nGame Number: ${data.gameNumber}\nOverall Odds: ${data.overallOdds}\nCash Odds: ${data.cashOdds}\nExpected Ticket Value: ${data.expectedValue}`;
-    document.getElementById('results').textContent = out;
+    const out = `Name: ${data.name}\nCost: ${data.cost}\nGame Number: ${data.gameNumber}\nOverall Odds: ${data.overallOdds}\nCash Odds: ${data.cashOdds}\nExpected Ticket Value: ${data.expectedValue}`;
+    results.textContent = out;
+    setStatus('Calculation complete.');
   } catch (err) {
-    document.getElementById('results').textContent = 'Error: ' + err.message;
+    results.textContent = '';
+    setStatus(`Error: ${err.message}`);
+  } finally {
+    setLoading(false);
   }
 }
 
-document.getElementById('calc').addEventListener('click', fetchTicket);
-const select = document.getElementById('ticketSelect');
+calcButton.addEventListener('click', fetchTicket);
+input.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    fetchTicket();
+  }
+});
+
 if (select) {
-  const input = document.getElementById('ticketUrl');
   input.value = select.value;
   select.addEventListener('change', () => {
     input.value = select.value;


### PR DESCRIPTION
### Motivation

- Provide a simple, shareable diagnostics page to capture verbose proxy fetch output for the recurring "Fetch failed" issue.  
- Make the main UI more usable and surface clearer error and loading state so users can see what's happening during fetches.  
- Harden parsing and validation logic so the app fails with clearer messages when the Lottery page layout or proxy responses differ.

### Description

- Add a dedicated diagnostic page `debug.html` and client script `debug.js` that test multiple public proxies (`api.allorigins.win` raw/get and `r.jina.ai`) and emit status, headers, and a content snippet for each proxy.  
- Link the debug page from the main UI (`index.html`) and document how to use it in `README.md`.  
- Refactor `script.js` to improve UX by adding a loading state, visible `#status` messages, Enter-key support, and clearer error messages for invalid URLs, missing prize tables, or proxy failures.  
- Improve prize table parsing to be more tolerant of DOM variations and add explicit checks that raise readable errors when required data (prize counts, overall odds, totals) cannot be computed.

### Testing

- Launched a local static server with `python3 -m http.server 8000` to serve the pages, which started successfully.  
- Attempted an automated Playwright screenshot of `debug.html` to validate rendering, but the headless Chromium instance crashed and the Playwright run failed with a browser SIGSEGV error.  
- No unit tests are present for this static site; changes are static/functional and intended to be validated by running the site and pasting diagnostic output from `debug.html` when reproducing the "Fetch failed" problem.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69810cdb2ee8832da8ef8199d49791b6)