### PR TITLE
Add scratchers overview placeholder page and improve fetch/parsing robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ Share the output so we can identify which proxy is failing.
 The script scrapes the prize table and other details using XPath selectors similar to those used with `IMPORTXML` in Google Sheets. It then computes an estimated expected value by scaling the number of non‑winning tickets according to the ratio of remaining winning tickets.
 
 **Note:** This tool relies on the structure of the California Lottery website. If the site's HTML changes or if cross-origin requests are blocked, the script may not work without adjustments.
-To avoid cross-origin restrictions, the page fetches scratcher URLs through the
-public `api.allorigins.win` proxy.
+To avoid cross-origin restrictions, the page fetches scratcher URLs through
+multiple public proxies (including `api.allorigins.win` and `r.jina.ai`) so it
+can fall back when one provider is unavailable.

--- a/debug.html
+++ b/debug.html
@@ -30,6 +30,6 @@
     Return to the <a href="index.html">main calculator</a>.
   </p>
 </main>
-<script src="debug.js"></script>
+<script src="debug.js?v=3"></script>
 </body>
 </html>

--- a/debug.js
+++ b/debug.js
@@ -24,7 +24,7 @@ const proxies = [
   },
   {
     name: 'r.jina.ai',
-    buildUrl: (url) => `https://r.jina.ai/http://r.jina.ai/http://${url.replace(/^https?:\/\//, '')}`,
+    buildUrl: (url) => `https://r.jina.ai/http://${url.replace(/^https?:\/\//, '')}`,
   },
 ];
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,13 @@
   #results { margin-top: 1.5rem; white-space: pre-wrap; background: #0b1b33; color: #f4f6fb; padding: 1rem; border-radius: 8px; }
   #status { margin-top: 0.75rem; color: #c45500; font-weight: 600; }
   .helper { color: #555; font-size: 0.95rem; }
+  #mathDetails { margin-top: 2rem; }
+  #mathDetails h2, #mathDetails h3 { margin-bottom: 0.5rem; }
+  #reconstructedTable { overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
+  th, td { border: 1px solid #d6dce6; padding: 0.5rem; text-align: left; }
+  th { background: #f0f4ff; }
+  .note { color: #3a4a5e; font-size: 0.9rem; }
 </style>
 </head>
 <body>
@@ -30,12 +37,22 @@
   <button id="calc" type="button">Calculate</button>
   <div id="status" role="status" aria-live="polite"></div>
   <div id="results" aria-live="polite"></div>
+  <section id="mathDetails" aria-live="polite">
+    <h2>Reconstructed Prize Table</h2>
+    <div id="reconstructedTable"></div>
+    <h3>Example Math</h3>
+    <div id="mathExample" class="helper"></div>
+  </section>
   <p class="helper">
     Seeing "Fetch failed"? Use the
     <a href="debug.html">debug page</a>
     to capture diagnostics for the proxy fetches.
   </p>
+  <p class="helper">
+    Browse all scratchers (placeholder table):
+    <a href="scratchers.html">scratchers overview</a>.
+  </p>
 </main>
-<script src="script.js"></script>
+<script src="script.js?v=6"></script>
 </body>
 </html>

--- a/scratchers.html
+++ b/scratchers.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>All Scratchers Overview</title>
+<style>
+  body { font-family: Arial, sans-serif; margin: 2em; background: #f6f6f6; color: #222; }
+  main { max-width: 980px; margin: 0 auto; background: #fff; padding: 2rem; border-radius: 12px; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06); }
+  h1 { margin-top: 0; }
+  table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+  th, td { border: 1px solid #d6dce6; padding: 0.6rem; text-align: left; }
+  th { background: #f0f4ff; }
+  .note { color: #3a4a5e; font-size: 0.95rem; }
+  a { color: #1b6ef3; }
+</style>
+</head>
+<body>
+<main>
+  <h1>All California Scratchers (Placeholder)</h1>
+  <p class="note">
+    This placeholder mirrors the categories shown at
+    <a href="https://www.calottery.com/en/scratchers" target="_blank" rel="noreferrer">calottery.com/en/scratchers</a>.
+    Each row is a stand-in for a scratcher game with the fields we plan to calculate.
+  </p>
+  <table>
+    <thead>
+      <tr>
+        <th>Price</th>
+        <th>Name + Number</th>
+        <th>Claimed Cash Odds</th>
+        <th>Calculated Cash Odds</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>$1</td>
+        <td>Example Game (1001)</td>
+        <td>1 in 5.12</td>
+        <td>1 in 5.45</td>
+      </tr>
+      <tr>
+        <td>$2</td>
+        <td>Example Game (1710)</td>
+        <td>1 in 5.08</td>
+        <td>1 in 5.33</td>
+      </tr>
+      <tr>
+        <td>$3</td>
+        <td>Example Game (1666)</td>
+        <td>1 in 3.74</td>
+        <td>1 in 3.91</td>
+      </tr>
+      <tr>
+        <td>$5</td>
+        <td>Example Game (1500)</td>
+        <td>1 in 4.20</td>
+        <td>1 in 4.37</td>
+      </tr>
+      <tr>
+        <td>$10</td>
+        <td>Example Game (1400)</td>
+        <td>1 in 3.50</td>
+        <td>1 in 3.68</td>
+      </tr>
+      <tr>
+        <td>$20</td>
+        <td>Example Game (1300)</td>
+        <td>1 in 3.00</td>
+        <td>1 in 3.12</td>
+      </tr>
+      <tr>
+        <td>$25</td>
+        <td>Example Game (1200)</td>
+        <td>1 in 2.90</td>
+        <td>1 in 3.04</td>
+      </tr>
+      <tr>
+        <td>$30</td>
+        <td>Example Game (1100)</td>
+        <td>1 in 2.80</td>
+        <td>1 in 2.95</td>
+      </tr>
+      <tr>
+        <td>$40</td>
+        <td>Example Game (1000)</td>
+        <td>1 in 2.70</td>
+        <td>1 in 2.86</td>
+      </tr>
+    </tbody>
+  </table>
+  <p class="note">
+    Next step: replace these placeholders with live data per scratcher category.
+  </p>
+  <p class="note"><a href="index.html">Back to calculator</a></p>
+</main>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,8 @@ const statusMessage = document.getElementById('status');
 const calcButton = document.getElementById('calc');
 const input = document.getElementById('ticketUrl');
 const select = document.getElementById('ticketSelect');
+const reconstructedTable = document.getElementById('reconstructedTable');
+const mathExample = document.getElementById('mathExample');
 
 const setStatus = (message = '') => {
   statusMessage.textContent = message;
@@ -12,20 +14,147 @@ const setLoading = (loading) => {
   calcButton.disabled = loading;
   if (loading) {
     results.textContent = '';
+    if (reconstructedTable) reconstructedTable.innerHTML = '';
+    if (mathExample) mathExample.textContent = '';
     setStatus('Loading ticket data...');
   }
 };
 
-const fetchTicketHtml = async (url) => {
-  const proxyUrl = 'https://api.allorigins.win/raw?url=' + encodeURIComponent(url);
-  const res = await fetch(proxyUrl);
-  if (!res.ok) {
-    throw new Error('Fetch failed. The proxy might be unavailable.');
+const proxies = [
+  {
+    name: 'allorigins raw',
+    buildUrl: (url) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`,
+  },
+  {
+    name: 'allorigins get',
+    buildUrl: (url) => `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`,
+    parse: (text) => {
+      try {
+        const data = JSON.parse(text);
+        return {
+          content: data.contents || '',
+          warning: data.status?.http_code ? `HTTP ${data.status.http_code}` : '',
+        };
+      } catch (error) {
+        return { content: '', warning: `JSON parse error: ${error.message}` };
+      }
+    },
+  },
+  {
+    name: 'r.jina.ai',
+    buildUrl: (url) => `https://r.jina.ai/http://${url.replace(/^https?:\/\//, '')}`,
+  },
+];
+
+const findPrizeTable = (doc) => {
+  const tables = Array.from(doc.querySelectorAll('table'));
+  for (const table of tables) {
+    const headerCells = Array.from(table.querySelectorAll('thead th'));
+    const headerText = headerCells.map((cell) => cell.textContent.trim().toLowerCase()).join(' ');
+    const hasPrize = headerText.includes('prize');
+    const hasRemaining = headerText.includes('remaining');
+    const hasOdds = headerText.includes('odds');
+    if (hasPrize && hasRemaining) {
+      return table;
+    }
+    if (headerCells.length === 0) {
+      const firstRow = table.querySelector('tr');
+      if (!firstRow) continue;
+      const rowText = Array.from(firstRow.querySelectorAll('td, th'))
+        .map((cell) => cell.textContent.trim().toLowerCase())
+        .join(' ');
+      if (rowText.includes('prize') && rowText.includes('remaining')) {
+        return table;
+      }
+    }
+    if (hasPrize && hasOdds) {
+      return table;
+    }
   }
-  return res.text();
+  return null;
+};
+
+const fetchTicketDocument = async (url) => {
+  const errors = [];
+  for (const proxy of proxies) {
+    try {
+      setStatus(`Fetching via ${proxy.name}...`);
+      const res = await fetch(proxy.buildUrl(url));
+      const text = await res.text();
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const parsed = proxy.parse ? proxy.parse(text) : { content: text, warning: '' };
+      const content = parsed.content?.trim() || '';
+      if (!content) {
+        throw new Error(parsed.warning || 'Empty response');
+      }
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(content, 'text/html');
+      const prizeTable = findPrizeTable(doc);
+      return { doc, prizeTable, rawText: content };
+    } catch (error) {
+      errors.push(`${proxy.name}: ${error.message}`);
+    }
+  }
+  throw new Error(`Fetch failed. Tried ${errors.length} proxies. ${errors.join(' | ')}`);
 };
 
 const textFromCell = (cell) => (cell ? cell.textContent.trim() : '');
+
+const escapeHtml = (value) =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const formatNumber = (value) => {
+  if (!Number.isFinite(value)) return 'n/a';
+  return value.toLocaleString('en-US', { maximumFractionDigits: 6 });
+};
+
+const formatCurrency = (value) => {
+  if (!Number.isFinite(value)) return 'n/a';
+  return value.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
+};
+
+const median = (values) => {
+  const sorted = values.filter((v) => Number.isFinite(v)).sort((a, b) => a - b);
+  if (!sorted.length) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+};
+
+const parseOddsValue = (text) => {
+  if (!text) return 0;
+  const match = text.match(/1\s*in\s*([0-9.,]+)/i);
+  if (match) {
+    return parseFloat(match[1].replace(/,/g, '')) || 0;
+  }
+  return parseFloat(text.replace(/[^0-9.]+/g, '')) || 0;
+};
+
+const extractLabelValue = (doc, labelRegex, valueRegex) => {
+  const elements = doc.querySelectorAll('p, li, div, span');
+  for (const el of elements) {
+    const text = el.textContent.replace(/\s+/g, ' ').trim();
+    if (!labelRegex.test(text)) continue;
+    const strong = el.querySelector('strong');
+    if (strong?.textContent.trim()) {
+      return strong.textContent.trim();
+    }
+    if (valueRegex) {
+      const match = text.match(valueRegex);
+      if (match?.[1]) return match[1].trim();
+    }
+  }
+  return '';
+};
 
 const parsePrizeCounts = (cell) => {
   if (!cell) return { remaining: '', initial: '' };
@@ -38,6 +167,24 @@ const parsePrizeCounts = (cell) => {
   }
   const parts = cell.textContent.split(/\s+/).filter(Boolean);
   return { remaining: parts[0] || '', initial: parts[1] || '' };
+};
+
+const parsePrizeRowsFromText = (text) => {
+  if (!text) return [];
+  const rows = [];
+  const lines = text.split(/\r?\n/).map((line) => line.trim());
+  const rowRegex = /^(\$[0-9,]+(?:\.[0-9]+)?|Ticket)\s+([0-9,]+)\s+([0-9,]+)\s+of\s+([0-9,]+)/i;
+  for (const line of lines) {
+    const match = line.match(rowRegex);
+    if (!match) continue;
+    rows.push({
+      prize: match[1],
+      odds: match[2],
+      remaining: match[3],
+      initial: match[4],
+    });
+  }
+  return rows;
 };
 
 async function fetchTicket() {
@@ -57,32 +204,45 @@ async function fetchTicket() {
 
   try {
     setLoading(true);
-    const html = await fetchTicketHtml(url);
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
+    const { doc, prizeTable, rawText } = await fetchTicketDocument(url);
 
     const xp = (path) => doc.evaluate(path, doc, null, XPathResult.STRING_TYPE, null).stringValue.trim();
     const data = {};
     data.name = xp('/html/head/title') || 'Unknown ticket';
-    data.cost = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Price") or contains(text(),"Cost")]/strong');
-    data.gameNumber = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Game")]/strong');
-    data.overallOdds = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Overall Odds")]/strong');
-    data.cashOdds = xp('//*[@id="section-content-1-1"]//p[contains(text(),"Cash Odds")]/strong');
+    data.cost =
+      xp('//*[@id="section-content-1-1"]//p[contains(text(),"Price") or contains(text(),"Cost")]/strong') ||
+      extractLabelValue(doc, /(price|cost)/i, /(?:price|cost)\s*:?\s*(\$?[0-9.,]+)/i);
+    data.gameNumber =
+      xp('//*[@id="section-content-1-1"]//p[contains(text(),"Game Number")]/strong') ||
+      extractLabelValue(doc, /game\s*number/i, /game\s*number\s*:?\s*([0-9]+)/i);
+    data.overallOdds =
+      xp('//*[@id="section-content-1-1"]//p[contains(text(),"Overall Odds")]/strong') ||
+      extractLabelValue(doc, /overall\s*odds/i, /(1\s*in\s*[0-9.,]+)/i);
+    data.cashOdds =
+      xp('//*[@id="section-content-1-1"]//p[contains(text(),"Cash Odds")]/strong') ||
+      extractLabelValue(doc, /cash\s*odds/i, /(1\s*in\s*[0-9.,]+)/i);
 
     const prizes = [];
-    const rows = doc.querySelectorAll('#section-content-1-3 table tbody tr');
-    rows.forEach((row, index) => {
-      if (index === 0) return;
-      const cells = row.querySelectorAll('td');
-      if (cells.length < 3) return;
-      const { remaining, initial } = parsePrizeCounts(cells[2]);
-      prizes.push({
-        prize: textFromCell(cells[0]),
-        odds: textFromCell(cells[1]),
-        remaining,
-        initial,
+    if (prizeTable) {
+      const rows = prizeTable.querySelectorAll('tbody tr').length
+        ? prizeTable.querySelectorAll('tbody tr')
+        : prizeTable.querySelectorAll('tr');
+      rows.forEach((row, index) => {
+        if (index === 0 && row.querySelectorAll('th').length) return;
+        const cells = row.querySelectorAll('td');
+        if (cells.length < 3) return;
+        const { remaining, initial } = parsePrizeCounts(cells[2]);
+        prizes.push({
+          prize: textFromCell(cells[0]),
+          odds: textFromCell(cells[1]),
+          remaining,
+          initial,
+        });
       });
-    });
+    } else {
+      const textRows = parsePrizeRowsFromText(rawText);
+      textRows.forEach((row) => prizes.push(row));
+    }
 
     if (!prizes.length) {
       throw new Error('No prize table found. The page layout may have changed.');
@@ -97,6 +257,9 @@ async function fetchTicket() {
       p.value = /ticket/i.test(p.prize) ? ticketCost : num(p.prize);
       p.remaining = num(p.remaining);
       p.initial = num(p.initial);
+      p.oddsRaw = p.odds;
+      p.oddsValue = parseOddsValue(p.oddsRaw);
+      p.totalTicketsEstimate = p.remaining && p.oddsValue ? p.remaining * p.oddsValue : 0;
       initialWinning += p.initial;
       currentWinning += p.remaining;
     });
@@ -105,26 +268,96 @@ async function fetchTicket() {
       throw new Error('Could not calculate remaining prizes. Missing prize counts.');
     }
 
-    const overall = parseFloat((data.overallOdds.match(/[0-9.]+/) || ['0'])[0]);
-    if (!overall) {
-      throw new Error('Overall odds were not found. The ticket page may have changed.');
+    const ticketTier = prizes.find((p) => /ticket/i.test(p.prize));
+    let totalRemainingTickets = 0;
+    if (ticketTier && ticketTier.initial && ticketTier.oddsValue) {
+      const initialTotalTickets = ticketTier.initial * ticketTier.oddsValue;
+      const remainingRatio = ticketTier.remaining / ticketTier.initial;
+      totalRemainingTickets = initialTotalTickets * remainingRatio;
     }
-    const totalInitial = initialWinning * overall;
-    const initialLosing = totalInitial - initialWinning;
-    const currentLosing = initialLosing * (currentWinning / initialWinning);
-    const totalRemaining = currentWinning + currentLosing;
-    if (!totalRemaining) {
-      throw new Error('Could not calculate remaining ticket totals.');
+    if (!totalRemainingTickets) {
+      totalRemainingTickets = median(prizes.map((p) => p.totalTicketsEstimate));
+    }
+    if (!totalRemainingTickets) {
+      throw new Error('Could not calculate remaining ticket totals from prize odds.');
     }
 
     let evPrize = 0;
     prizes.forEach((p) => {
-      evPrize += (p.remaining / totalRemaining) * p.value;
+      p.probability = p.remaining / totalRemainingTickets;
+      evPrize += p.probability * p.value;
     });
 
     data.expectedValue = (evPrize - ticketCost).toFixed(4);
-    const out = `Name: ${data.name}\nCost: ${data.cost}\nGame Number: ${data.gameNumber}\nOverall Odds: ${data.overallOdds}\nCash Odds: ${data.cashOdds}\nExpected Ticket Value: ${data.expectedValue}`;
+    const displayValue = (value) => (value ? value : 'n/a');
+    const out = `Name: ${displayValue(data.name)}\nCost: ${displayValue(data.cost)}\nGame Number: ${displayValue(
+      data.gameNumber
+    )}\nOverall Odds: ${displayValue(data.overallOdds)}\nCash Odds: ${displayValue(
+      data.cashOdds
+    )}\nExpected Ticket Value: ${data.expectedValue}`;
     results.textContent = out;
+    if (reconstructedTable) {
+      const tableRows = prizes
+        .map(
+          (p) => `<tr>
+            <td>${escapeHtml(p.prize)}</td>
+            <td>${escapeHtml(p.oddsRaw)}</td>
+            <td>${formatNumber(p.remaining)}</td>
+            <td>${formatNumber(p.initial)}</td>
+            <td>${formatNumber(p.oddsValue)}</td>
+            <td>${formatNumber(p.totalTicketsEstimate)}</td>
+            <td>${formatNumber(p.probability)}</td>
+            <td>${formatCurrency(p.value)}</td>
+          </tr>`
+        )
+        .join('');
+      const estimationNote = ticketTier
+        ? 'We anchor total remaining tickets to the Ticket tier, then compute probabilities as Remaining ÷ total.'
+        : 'We estimate total remaining tickets from each tier as Remaining × (1 in N odds), then use the median of those estimates to compute probabilities.';
+      reconstructedTable.innerHTML = `
+        <p class="note">${estimationNote}</p>
+        <table>
+          <thead>
+            <tr>
+              <th>Prize</th>
+              <th>Odds (1 in N)</th>
+              <th>Remaining</th>
+              <th>Total</th>
+              <th>Parsed N</th>
+              <th>Estimated Total Tickets (X×N)</th>
+              <th>Probability</th>
+              <th>Prize Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${tableRows}
+          </tbody>
+        </table>
+        <p class="note">Total remaining tickets: ${formatNumber(totalRemainingTickets)}</p>
+      `;
+    }
+    if (mathExample) {
+      const sample = prizes.find((p) => p.totalTicketsEstimate);
+      if (sample) {
+        const ticketRatio =
+          ticketTier && ticketTier.initial ? ticketTier.remaining / ticketTier.initial : 0;
+        const anchorText = ticketTier
+          ? `Ticket tier anchor: ${formatNumber(ticketTier.remaining)} ÷ ${formatNumber(
+              ticketTier.initial
+            )} = ${formatNumber(ticketRatio)} remaining ratio.`
+          : `Median total tickets across tiers = ${formatNumber(totalRemainingTickets)}.`;
+        mathExample.textContent = `Example: For ${sample.prize}, total tickets estimate ≈ ${formatNumber(
+          sample.remaining
+        )} × ${formatNumber(sample.oddsValue)} = ${formatNumber(
+          sample.totalTicketsEstimate
+        )}. ${anchorText} Probability = ${formatNumber(sample.remaining)} ÷ ${formatNumber(
+          totalRemainingTickets
+        )} = ${formatNumber(sample.probability)}. Expected value contribution = probability × prize value.`;
+      } else {
+        mathExample.textContent =
+          'Example: Total tickets are estimated as Remaining × (1 in N odds). Probability is Remaining divided by the estimated total tickets.';
+      }
+    }
     setStatus('Calculation complete.');
   } catch (err) {
     results.textContent = '';


### PR DESCRIPTION
### Motivation
- Provide a placeholder page that lists all statewide scratcher price categories and the fields we plan to calculate (Price, Name + Number, Claimed Cash Odds, Calculated Cash Odds). 
- Improve resilience of ticket fetching and prize-table parsing when proxies return wrapped JSON, raw text, or pages with changed HTML structure. 
- Make probability/EV estimation more transparent by reconstructing a prize table and showing the anchoring/math used to estimate total remaining tickets.

### Description
- Add `scratchers.html` as a placeholder overview page with a table for `Price`, `Name + Number`, `Claimed Cash Odds`, and `Calculated Cash Odds`, and link it from `index.html` via a new helper link. 
- Replace the single-proxy fetch with a `proxies` list and a new `fetchTicketDocument` flow that tries multiple proxies and returns `{ doc, prizeTable, rawText }`. 
- Add `findPrizeTable` heuristics and a `parsePrizeRowsFromText` regex fallback for extracting prize rows when an HTML table is not found, plus `extractLabelValue` and `parseOddsValue` helpers to harden metadata parsing. 
- Estimate total remaining tickets by anchoring to the Ticket tier when available or falling back to the median of per-tier `Remaining × N` estimates, and compute per-tier probabilities accordingly. 
- Render a reconstructed prize table and an example math explanation in the UI via new DOM targets `#reconstructedTable` and `#mathExample`, and add formatting/escaping helpers like `escapeHtml`, `formatNumber`, and `formatCurrency`. 
- Fix the `r.jina.ai` proxy URL usage and bump cache-bust query strings (`script.js?v=6` and `debug.js?v=3`) so updated logic is loaded. 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69839e8a812c832dbd26a3519246603a)