### PR TITLE
Add scratchers overview navigation and dynamic list

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,9 @@
 </head>
 <body>
 <main>
+  <nav class="helper">
+    <a href="scratchers.html">Scratchers overview</a>
+  </nav>
   <h1>California Scratch Ticket Expected Value</h1>
   <p class="helper">Pick a known scratcher or paste any California Lottery scratcher URL to estimate expected ticket value from the remaining prizes table.</p>
   <label for="ticketSelect">Choose a scratcher</label>
@@ -49,7 +52,7 @@
     to capture diagnostics for the proxy fetches.
   </p>
   <p class="helper">
-    Browse all scratchers (placeholder table):
+    Browse all scratchers:
     <a href="scratchers.html">scratchers overview</a>.
   </p>
 </main>

--- a/scratchers.html
+++ b/scratchers.html
@@ -16,12 +16,13 @@
 </head>
 <body>
 <main>
-  <h1>All California Scratchers (Placeholder)</h1>
+  <h1>All California Scratchers</h1>
   <p class="note">
-    This placeholder mirrors the categories shown at
+    This list is populated from
     <a href="https://www.calottery.com/en/scratchers" target="_blank" rel="noreferrer">calottery.com/en/scratchers</a>.
-    Each row is a stand-in for a scratcher game with the fields we plan to calculate.
+    Claimed odds, calculated odds, and expected value are placeholders until we wire up the full calculations.
   </p>
+  <p id="status" class="note" role="status" aria-live="polite"></p>
   <table>
     <thead>
       <tr>
@@ -29,69 +30,16 @@
         <th>Name + Number</th>
         <th>Claimed Cash Odds</th>
         <th>Calculated Cash Odds</th>
+        <th>Expected Value</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td>$1</td>
-        <td>Example Game (1001)</td>
-        <td>1 in 5.12</td>
-        <td>1 in 5.45</td>
-      </tr>
-      <tr>
-        <td>$2</td>
-        <td>Example Game (1710)</td>
-        <td>1 in 5.08</td>
-        <td>1 in 5.33</td>
-      </tr>
-      <tr>
-        <td>$3</td>
-        <td>Example Game (1666)</td>
-        <td>1 in 3.74</td>
-        <td>1 in 3.91</td>
-      </tr>
-      <tr>
-        <td>$5</td>
-        <td>Example Game (1500)</td>
-        <td>1 in 4.20</td>
-        <td>1 in 4.37</td>
-      </tr>
-      <tr>
-        <td>$10</td>
-        <td>Example Game (1400)</td>
-        <td>1 in 3.50</td>
-        <td>1 in 3.68</td>
-      </tr>
-      <tr>
-        <td>$20</td>
-        <td>Example Game (1300)</td>
-        <td>1 in 3.00</td>
-        <td>1 in 3.12</td>
-      </tr>
-      <tr>
-        <td>$25</td>
-        <td>Example Game (1200)</td>
-        <td>1 in 2.90</td>
-        <td>1 in 3.04</td>
-      </tr>
-      <tr>
-        <td>$30</td>
-        <td>Example Game (1100)</td>
-        <td>1 in 2.80</td>
-        <td>1 in 2.95</td>
-      </tr>
-      <tr>
-        <td>$40</td>
-        <td>Example Game (1000)</td>
-        <td>1 in 2.70</td>
-        <td>1 in 2.86</td>
-      </tr>
-    </tbody>
+    <tbody id="scratchersBody"></tbody>
   </table>
   <p class="note">
-    Next step: replace these placeholders with live data per scratcher category.
+    Next step: replace placeholder odds/EV with live data per scratcher.
   </p>
   <p class="note"><a href="index.html">Back to calculator</a></p>
 </main>
+<script src="scratchers.js?v=1"></script>
 </body>
 </html>

--- a/scratchers.js
+++ b/scratchers.js
@@ -1,0 +1,153 @@
+const scratchersBody = document.getElementById('scratchersBody');
+const statusMessage = document.getElementById('status');
+
+const setStatus = (message = '') => {
+  if (statusMessage) statusMessage.textContent = message;
+};
+
+const proxies = [
+  {
+    name: 'allorigins raw',
+    buildUrl: (url) => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`,
+  },
+  {
+    name: 'allorigins get',
+    buildUrl: (url) => `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`,
+    parse: (text) => {
+      try {
+        const data = JSON.parse(text);
+        return {
+          content: data.contents || '',
+          warning: data.status?.http_code ? `HTTP ${data.status.http_code}` : '',
+        };
+      } catch (error) {
+        return { content: '', warning: `JSON parse error: ${error.message}` };
+      }
+    },
+  },
+  {
+    name: 'r.jina.ai',
+    buildUrl: (url) => `https://r.jina.ai/http://${url.replace(/^https?:\/\//, '')}`,
+  },
+];
+
+const escapeHtml = (value) =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const fetchScratchersDocument = async (url) => {
+  const errors = [];
+  for (const proxy of proxies) {
+    try {
+      setStatus(`Fetching scratchers via ${proxy.name}...`);
+      const res = await fetch(proxy.buildUrl(url));
+      const text = await res.text();
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const parsed = proxy.parse ? proxy.parse(text) : { content: text, warning: '' };
+      const content = parsed.content?.trim() || '';
+      if (!content) {
+        throw new Error(parsed.warning || 'Empty response');
+      }
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(content, 'text/html');
+      return { doc, rawText: content };
+    } catch (error) {
+      errors.push(`${proxy.name}: ${error.message}`);
+    }
+  }
+  throw new Error(`Fetch failed. Tried ${errors.length} proxies. ${errors.join(' | ')}`);
+};
+
+const normalizeName = (value) => value.replace(/\s+/g, ' ').trim();
+
+const parseGameInfoFromUrl = (url) => {
+  const priceMatch = url.match(/\/scratchers\/\$?([0-9]+)/i);
+  const price = priceMatch ? `$${priceMatch[1]}` : '—';
+  const slug = url.split('/').filter(Boolean).pop() || '';
+  const slugParts = slug.split('-');
+  const lastPart = slugParts[slugParts.length - 1];
+  const gameNumber = /^\d{3,}$/.test(lastPart) ? lastPart : '';
+  const nameFromSlug = gameNumber ? slugParts.slice(0, -1).join(' ') : slugParts.join(' ');
+  return {
+    price,
+    gameNumber,
+    nameFromSlug: normalizeName(nameFromSlug.replace(/\bca(?:lifornia)?\b/gi, '')),
+  };
+};
+
+const extractScratchersFromLinks = (doc, baseUrl) => {
+  const links = Array.from(doc.querySelectorAll('a[href*="/scratchers/"]'));
+  const items = new Map();
+
+  links.forEach((link) => {
+    const href = link.getAttribute('href');
+    if (!href) return;
+    if (!/\/scratchers\/\$?[0-9]+/i.test(href)) return;
+    const absoluteUrl = new URL(href, baseUrl).toString();
+    const { price, gameNumber, nameFromSlug } = parseGameInfoFromUrl(absoluteUrl);
+    const textName = normalizeName(link.textContent);
+    const name = textName || nameFromSlug || 'Unknown scratcher';
+    const displayName = gameNumber ? `${name} (${gameNumber})` : name;
+    if (items.has(absoluteUrl)) return;
+    items.set(absoluteUrl, {
+      price,
+      name: displayName,
+      url: absoluteUrl,
+    });
+  });
+
+  return Array.from(items.values());
+};
+
+const renderScratchers = (scratchers) => {
+  if (!scratchersBody) return;
+  if (!scratchers.length) {
+    scratchersBody.innerHTML =
+      '<tr><td colspan="5">No scratchers found. Try again later.</td></tr>';
+    return;
+  }
+
+  const rows = scratchers
+    .map(
+      (scratcher) => `<tr>
+        <td>${escapeHtml(scratcher.price)}</td>
+        <td><a href="${escapeHtml(scratcher.url)}" target="_blank" rel="noreferrer">${escapeHtml(
+        scratcher.name
+      )}</a></td>
+        <td>—</td>
+        <td>—</td>
+        <td>—</td>
+      </tr>`
+    )
+    .join('');
+  scratchersBody.innerHTML = rows;
+};
+
+const sortScratchers = (scratchers) =>
+  scratchers.sort((a, b) => {
+    const priceA = parseFloat((a.price || '').replace(/[^0-9.]/g, '')) || 0;
+    const priceB = parseFloat((b.price || '').replace(/[^0-9.]/g, '')) || 0;
+    if (priceA !== priceB) return priceA - priceB;
+    return a.name.localeCompare(b.name);
+  });
+
+const loadScratchers = async () => {
+  try {
+    setStatus('Loading scratchers...');
+    const { doc } = await fetchScratchersDocument('https://www.calottery.com/en/scratchers');
+    const scratchers = sortScratchers(extractScratchersFromLinks(doc, window.location.href));
+    renderScratchers(scratchers);
+    setStatus(`Loaded ${scratchers.length} scratchers.`);
+  } catch (error) {
+    setStatus(`Error: ${error.message}`);
+    renderScratchers([]);
+  }
+};
+
+loadScratchers();


### PR DESCRIPTION
### Motivation
- Make it easy to navigate from the calculator to the full scratchers overview. 
- Replace a static placeholder table with a page that can discover all scratchers so we can later compute odds and EV programmatically. 
- Provide a lightweight client-side scraper to gather scratcher `name`, `price`, and `url` as a foundation for future calculations.

### Description
- Added a navigation entry to `index.html` linking to the scratchers overview and simplified the helper copy. 
- Reworked `scratchers.html` to remove the hard-coded placeholder rows, add a status element, an `Expected Value` column, and include `scratchers.js`. 
- Added `scratchers.js` which fetches `https://www.calottery.com/en/scratchers` via multiple proxy endpoints, parses scratcher links to extract `price`, `name`, and `gameNumber`, sorts the results, and renders the table rows with placeholder cells for claimed odds, calculated odds, and expected value.

### Testing
- Launched a local HTTP server and used Playwright to load `scratchers.html` and capture a screenshot of the rendered page, and the run completed successfully. 
- Verified files were staged and committed (`index.html`, `scratchers.html`, `scratchers.js`) as part of the change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983d7ec3be0832d98bff1984c0a41f3)