### PR TITLE
Load full scratchers list via official Calottery API with robust fallbacks

### DIFF
--- a/scratchers.js
+++ b/scratchers.js
@@ -64,6 +64,29 @@ const fetchScratchersDocument = async (url) => {
   throw new Error(`Fetch failed. Tried ${errors.length} proxies. ${errors.join(' | ')}`);
 };
 
+const fetchViaProxies = async (url, statusLabel) => {
+  const errors = [];
+  for (const proxy of proxies) {
+    try {
+      if (statusLabel) setStatus(`${statusLabel} via ${proxy.name}...`);
+      const res = await fetch(proxy.buildUrl(url));
+      const text = await res.text();
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const parsed = proxy.parse ? proxy.parse(text) : { content: text, warning: '' };
+      const content = parsed.content?.trim() || '';
+      if (!content) {
+        throw new Error(parsed.warning || 'Empty response');
+      }
+      return content;
+    } catch (error) {
+      errors.push(`${proxy.name}: ${error.message}`);
+    }
+  }
+  throw new Error(`Fetch failed. Tried ${errors.length} proxies. ${errors.join(' | ')}`);
+};
+
 const normalizeName = (value) => value.replace(/\s+/g, ' ').trim();
 
 const parseGameInfoFromUrl = (url) => {
@@ -105,6 +128,167 @@ const extractScratchersFromLinks = (doc, baseUrl) => {
   return Array.from(items.values());
 };
 
+const extractScratchersFromText = (rawText, baseUrl) => {
+  const items = new Map();
+  if (!rawText) return [];
+  const urlMatches = rawText.matchAll(
+    /https?:\/\/[^"'\s)]+\/scratchers\/\$?\d+\/[a-z0-9-]+/gi
+  );
+  const pathMatches = rawText.matchAll(/\/scratchers\/\$?\d+\/[a-z0-9-]+/gi);
+
+  const addUrl = (url) => {
+    try {
+      const absoluteUrl = new URL(url, baseUrl).toString();
+      const { price, gameNumber, nameFromSlug } = parseGameInfoFromUrl(absoluteUrl);
+      const displayName = gameNumber ? `${nameFromSlug} (${gameNumber})` : nameFromSlug;
+      if (!items.has(absoluteUrl)) {
+        items.set(absoluteUrl, {
+          price,
+          name: displayName || 'Unknown scratcher',
+          url: absoluteUrl,
+        });
+      }
+    } catch (error) {
+      return;
+    }
+  };
+
+  for (const match of urlMatches) {
+    addUrl(match[0]);
+  }
+  for (const match of pathMatches) {
+    addUrl(match[0]);
+  }
+
+  return Array.from(items.values());
+};
+
+const findScratchersApiUrl = (rawText, baseUrl) => {
+  if (!rawText) return '';
+  const absoluteMatch = rawText.match(
+    /https?:\/\/www\.calottery\.com\/sitecore\/api\/ssc\/scratchers\/[a-z0-9/?&=_-]+/i
+  );
+  if (absoluteMatch) return absoluteMatch[0];
+  const relativeMatch = rawText.match(/\/sitecore\/api\/ssc\/scratchers\/[a-z0-9/?&=_-]+/i);
+  if (relativeMatch) return new URL(relativeMatch[0], baseUrl).toString();
+  return '';
+};
+
+const parseScratchersFromGamesApi = (data, baseUrl) => {
+  if (!data || typeof data !== 'object') return [];
+  const games = Array.isArray(data.games) ? data.games : [];
+  return games
+    .map((game) => {
+      const rawUrl = game.productPage || game.url || game.gameUrl || '';
+      const name = game.name || game.gameName || '';
+      const gameNumber = game.gameNumber || game.number || '';
+      const price = game.price ?? '';
+      if (!rawUrl || !name) return null;
+      let url = rawUrl;
+      try {
+        url = new URL(rawUrl, baseUrl).toString();
+      } catch (error) {
+        return null;
+      }
+      const priceLabel =
+        typeof price === 'number' || /^\d/.test(String(price)) ? `$${price}` : price || '—';
+      const displayName = gameNumber ? `${name} (${gameNumber})` : name;
+      return {
+        price: priceLabel,
+        name: displayName,
+        url,
+      };
+    })
+    .filter(Boolean);
+};
+
+const parseScratchersFromApiData = (data, baseUrl) => {
+  if (!data) return [];
+  const pickArray = (value) => {
+    if (Array.isArray(value)) return value;
+    if (!value || typeof value !== 'object') return [];
+    const candidates = [
+      value.scratchers,
+      value.games,
+      value.data,
+      value.results,
+      value.items,
+      value.Scratchers,
+      value.Games,
+      value.Data,
+      value.Results,
+    ];
+    for (const candidate of candidates) {
+      if (Array.isArray(candidate)) return candidate;
+    }
+    return [];
+  };
+
+  const records = Array.isArray(data) ? data : pickArray(data);
+  return records
+    .map((record) => {
+      const rawUrl =
+        record.gameUrl ||
+        record.gameURL ||
+        record.url ||
+        record.link ||
+        record.detailUrl ||
+        record.detailURL ||
+        record.detailPageUrl ||
+        '';
+      const name =
+        record.gameName ||
+        record.name ||
+        record.title ||
+        record.GameName ||
+        record.Name ||
+        record.Title ||
+        '';
+      const gameNumber =
+        record.gameNumber ||
+        record.GameNumber ||
+        record.gameId ||
+        record.GameId ||
+        record.number ||
+        '';
+      const price =
+        record.price ||
+        record.Price ||
+        record.ticketPrice ||
+        record.TicketPrice ||
+        record.cost ||
+        record.Cost ||
+        '';
+      if (!rawUrl || !name) return null;
+      let url = rawUrl;
+      try {
+        url = new URL(rawUrl, baseUrl).toString();
+      } catch (error) {
+        return null;
+      }
+      const priceLabel =
+        typeof price === 'number' || /^\d/.test(String(price)) ? `$${price}` : price || '—';
+      const displayName = gameNumber ? `${name} (${gameNumber})` : name;
+      return {
+        price: priceLabel,
+        name: displayName,
+        url,
+      };
+    })
+    .filter(Boolean);
+};
+
+const extractScratchers = (doc, rawText, baseUrl) => {
+  const items = new Map();
+  const linkItems = extractScratchersFromLinks(doc, baseUrl);
+  linkItems.forEach((item) => items.set(item.url, item));
+  const textItems = extractScratchersFromText(rawText, baseUrl);
+  textItems.forEach((item) => {
+    if (!items.has(item.url)) items.set(item.url, item);
+  });
+  return Array.from(items.values());
+};
+
 const renderScratchers = (scratchers) => {
   if (!scratchersBody) return;
   if (!scratchers.length) {
@@ -140,8 +324,36 @@ const sortScratchers = (scratchers) =>
 const loadScratchers = async () => {
   try {
     setStatus('Loading scratchers...');
-    const { doc } = await fetchScratchersDocument('https://www.calottery.com/en/scratchers');
-    const scratchers = sortScratchers(extractScratchersFromLinks(doc, window.location.href));
+    const sourceUrl = 'https://www.calottery.com/en/scratchers';
+    const { doc, rawText } = await fetchScratchersDocument(sourceUrl);
+    const baseUrl = new URL(sourceUrl).origin;
+    let scratchers = [];
+    try {
+      const apiResponse = await fetchViaProxies(
+        'https://www.calottery.com/api/games/scratchers',
+        'Fetching scratchers data'
+      );
+      const apiData = JSON.parse(apiResponse);
+      scratchers = parseScratchersFromGamesApi(apiData, baseUrl);
+    } catch (error) {
+      scratchers = [];
+    }
+    if (!scratchers.length) {
+      const apiUrl = findScratchersApiUrl(rawText, baseUrl);
+      if (apiUrl) {
+        try {
+          const apiResponse = await fetchViaProxies(apiUrl, 'Fetching scratchers data');
+          const apiData = JSON.parse(apiResponse);
+          scratchers = parseScratchersFromApiData(apiData, baseUrl);
+        } catch (error) {
+          scratchers = [];
+        }
+      }
+    }
+    if (!scratchers.length) {
+      scratchers = extractScratchers(doc, rawText, baseUrl);
+    }
+    scratchers = sortScratchers(scratchers);
     renderScratchers(scratchers);
     setStatus(`Loaded ${scratchers.length} scratchers.`);
   } catch (error) {


### PR DESCRIPTION
### Motivation
- The site exposes an official games API that lists all active scratchers, so relying on HTML-only scraping misses many tickets and is brittle.
- Prefer structured data when available to reliably surface every active ticket and produce canonical absolute URLs and normalized price/name fields.
- Keep resilient behavior by falling back to discovered Sitecore endpoints and HTML/text extraction when APIs are unavailable.

### Description
- Added `fetchViaProxies` helper to reuse the existing proxy mechanism for auxiliary API fetches and to surface proxy-specific errors.
- Added `parseScratchersFromGamesApi(data, baseUrl)` to parse the official `https://www.calottery.com/api/games/scratchers` response and normalize `price`, `name`, and resolved `url` fields.
- Implemented `extractScratchersFromText` to find scratcher paths and absolute URLs embedded in raw page text and to normalize them via `parseGameInfoFromUrl`.
- Updated `loadScratchers` to prefer the official games API, then fall back to a discovered Sitecore SCRATCHERS API via `findScratchersApiUrl`, and finally fall back to combined HTML/text scraping; results remain deduped, sorted, and rendered.

### Testing
- Ran a headless Playwright validation that requested `https://www.calottery.com/api/games/scratchers` and received a `200` response with a `games` array showing the expected fields, confirming the API is reachable and structured as parsed.
- No unit or CI test suite was executed against the modified code in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e1f54998832da6e3aec88cdcf1ec)