### PR TITLE
Add EV Delta heatmap column and improve scratchers fetching/parsing

### DIFF
--- a/scratchers.html
+++ b/scratchers.html
@@ -30,7 +30,9 @@
         <th>Name + Number</th>
         <th>Claimed Cash Odds</th>
         <th>Calculated Cash Odds</th>
-        <th>Expected Value</th>
+        <th>Claimed Expected Value</th>
+        <th>Calculated Expected Value</th>
+        <th>EV Delta</th>
       </tr>
     </thead>
     <tbody id="scratchersBody"></tbody>

--- a/scratchers.js
+++ b/scratchers.js
@@ -27,7 +27,11 @@ const proxies = [
   },
   {
     name: 'r.jina.ai',
-    buildUrl: (url) => `https://r.jina.ai/http://${url.replace(/^https?:\/\//, '')}`,
+    buildUrl: (url) => {
+      const scheme = url.startsWith('https://') ? 'https://' : 'http://';
+      const normalized = url.replace(/^https?:\/\//, '');
+      return `https://r.jina.ai/${scheme}${normalized}`;
+    },
   },
 ];
 
@@ -57,6 +61,29 @@ const fetchScratchersDocument = async (url) => {
       const parser = new DOMParser();
       const doc = parser.parseFromString(content, 'text/html');
       return { doc, rawText: content };
+    } catch (error) {
+      errors.push(`${proxy.name}: ${error.message}`);
+    }
+  }
+  throw new Error(`Fetch failed. Tried ${errors.length} proxies. ${errors.join(' | ')}`);
+};
+
+const fetchViaProxies = async (url, statusLabel) => {
+  const errors = [];
+  for (const proxy of proxies) {
+    try {
+      if (statusLabel) setStatus(`${statusLabel} via ${proxy.name}...`);
+      const res = await fetch(proxy.buildUrl(url));
+      const text = await res.text();
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const parsed = proxy.parse ? proxy.parse(text) : { content: text, warning: '' };
+      const content = parsed.content?.trim() || '';
+      if (!content) {
+        throw new Error(parsed.warning || 'Empty response');
+      }
+      return content;
     } catch (error) {
       errors.push(`${proxy.name}: ${error.message}`);
     }
@@ -105,6 +132,228 @@ const extractScratchersFromLinks = (doc, baseUrl) => {
   return Array.from(items.values());
 };
 
+const extractScratchersFromText = (rawText, baseUrl) => {
+  const items = new Map();
+  if (!rawText) return [];
+  const urlMatches = rawText.matchAll(
+    /https?:\/\/[^"'\s)]+\/scratchers\/\$?\d+\/[a-z0-9-]+/gi
+  );
+  const pathMatches = rawText.matchAll(/\/scratchers\/\$?\d+\/[a-z0-9-]+/gi);
+
+  const addUrl = (url) => {
+    try {
+      const absoluteUrl = new URL(url, baseUrl).toString();
+      const { price, gameNumber, nameFromSlug } = parseGameInfoFromUrl(absoluteUrl);
+      const displayName = gameNumber ? `${nameFromSlug} (${gameNumber})` : nameFromSlug;
+      if (!items.has(absoluteUrl)) {
+        items.set(absoluteUrl, {
+          price,
+          name: displayName || 'Unknown scratcher',
+          url: absoluteUrl,
+        });
+      }
+    } catch (error) {
+      return;
+    }
+  };
+
+  for (const match of urlMatches) {
+    addUrl(match[0]);
+  }
+  for (const match of pathMatches) {
+    addUrl(match[0]);
+  }
+
+  return Array.from(items.values());
+};
+
+const findScratchersApiUrl = (rawText, baseUrl) => {
+  if (!rawText) return '';
+  const absoluteMatch = rawText.match(
+    /https?:\/\/www\.calottery\.com\/sitecore\/api\/ssc\/scratchers\/[a-z0-9/?&=_-]+/i
+  );
+  if (absoluteMatch) return absoluteMatch[0];
+  const relativeMatch = rawText.match(/\/sitecore\/api\/ssc\/scratchers\/[a-z0-9/?&=_-]+/i);
+  if (relativeMatch) return new URL(relativeMatch[0], baseUrl).toString();
+  return '';
+};
+
+const calculateStatsFromPrizeTiers = (prizeTiers, ticketPrice) => {
+  if (!prizeTiers.length) {
+    return { calculatedCashOdds: null, expectedValue: null, claimedExpectedValue: null };
+  }
+  let totalPrizes = 0;
+  let remainingPrizes = 0;
+  let expectedValueNumerator = 0;
+  let claimedExpectedValueNumerator = 0;
+  const ticketEstimates = [];
+
+  prizeTiers.forEach((tier) => {
+    const total = Number(tier.totalNumberOfPrizes) || 0;
+    const remaining = Number(tier.numberOfPrizesPending) || 0;
+    const odds = Number(tier.odds);
+    const value = Number(tier.value) || 0;
+    if (total && Number.isFinite(odds)) {
+      ticketEstimates.push(odds * total);
+    }
+    totalPrizes += total;
+    remainingPrizes += remaining;
+    expectedValueNumerator += value * remaining;
+    claimedExpectedValueNumerator += value * total;
+  });
+
+  if (!remainingPrizes || !totalPrizes || !ticketEstimates.length) {
+    return { calculatedCashOdds: null, expectedValue: null, claimedExpectedValue: null };
+  }
+
+  const estimatedTickets =
+    ticketEstimates.reduce((sum, estimate) => sum + estimate, 0) / ticketEstimates.length;
+  const remainingTickets = estimatedTickets * (remainingPrizes / totalPrizes);
+  if (!remainingTickets) {
+    return { calculatedCashOdds: null, expectedValue: null, claimedExpectedValue: null };
+  }
+
+  const claimedExpectedValue = claimedExpectedValueNumerator / estimatedTickets;
+  const netClaimedExpectedValue =
+    Number.isFinite(claimedExpectedValue) && Number.isFinite(ticketPrice)
+      ? claimedExpectedValue - ticketPrice
+      : null;
+  const expectedValue = expectedValueNumerator / remainingTickets;
+  const netExpectedValue =
+    Number.isFinite(expectedValue) && Number.isFinite(ticketPrice)
+      ? expectedValue - ticketPrice
+      : null;
+
+  return {
+    calculatedCashOdds: remainingTickets / remainingPrizes,
+    expectedValue: netExpectedValue,
+    claimedExpectedValue: netClaimedExpectedValue,
+  };
+};
+
+const parseScratchersFromGamesApi = (data, baseUrl) => {
+  if (!data || typeof data !== 'object') return [];
+  const games = Array.isArray(data.games) ? data.games : [];
+  return games
+    .map((game) => {
+      const rawUrl = game.productPage || game.url || game.gameUrl || '';
+      const name = game.name || game.gameName || '';
+      const gameNumber = game.gameNumber || game.number || '';
+      const price = game.price ?? '';
+      const claimedCashOdds = game.cashOdds ?? '';
+      const prizeTiers = Array.isArray(game.prizeTiers) ? game.prizeTiers : [];
+      if (!rawUrl || !name) return null;
+      let url = rawUrl;
+      try {
+        url = new URL(rawUrl, baseUrl).toString();
+      } catch (error) {
+        return null;
+      }
+      const priceLabel =
+        typeof price === 'number' || /^\d/.test(String(price)) ? `$${price}` : price || '—';
+      const displayName = gameNumber ? `${name} (${gameNumber})` : name;
+      const numericPrice = Number(price);
+      const stats = calculateStatsFromPrizeTiers(prizeTiers, numericPrice);
+      return {
+        price: priceLabel,
+        name: displayName,
+        url,
+        claimedCashOdds,
+        calculatedCashOdds: stats.calculatedCashOdds,
+        claimedExpectedValue: stats.claimedExpectedValue,
+        expectedValue: stats.expectedValue,
+      };
+    })
+    .filter(Boolean);
+};
+
+const parseScratchersFromApiData = (data, baseUrl) => {
+  if (!data) return [];
+  const pickArray = (value) => {
+    if (Array.isArray(value)) return value;
+    if (!value || typeof value !== 'object') return [];
+    const candidates = [
+      value.scratchers,
+      value.games,
+      value.data,
+      value.results,
+      value.items,
+      value.Scratchers,
+      value.Games,
+      value.Data,
+      value.Results,
+    ];
+    for (const candidate of candidates) {
+      if (Array.isArray(candidate)) return candidate;
+    }
+    return [];
+  };
+
+  const records = Array.isArray(data) ? data : pickArray(data);
+  return records
+    .map((record) => {
+      const rawUrl =
+        record.gameUrl ||
+        record.gameURL ||
+        record.url ||
+        record.link ||
+        record.detailUrl ||
+        record.detailURL ||
+        record.detailPageUrl ||
+        '';
+      const name =
+        record.gameName ||
+        record.name ||
+        record.title ||
+        record.GameName ||
+        record.Name ||
+        record.Title ||
+        '';
+      const gameNumber =
+        record.gameNumber ||
+        record.GameNumber ||
+        record.gameId ||
+        record.GameId ||
+        record.number ||
+        '';
+      const price =
+        record.price ||
+        record.Price ||
+        record.ticketPrice ||
+        record.TicketPrice ||
+        record.cost ||
+        record.Cost ||
+        '';
+      if (!rawUrl || !name) return null;
+      let url = rawUrl;
+      try {
+        url = new URL(rawUrl, baseUrl).toString();
+      } catch (error) {
+        return null;
+      }
+      const priceLabel =
+        typeof price === 'number' || /^\d/.test(String(price)) ? `$${price}` : price || '—';
+      const displayName = gameNumber ? `${name} (${gameNumber})` : name;
+      return {
+        price: priceLabel,
+        name: displayName,
+        url,
+      };
+    })
+    .filter(Boolean);
+};
+
+const extractScratchers = (doc, rawText, baseUrl) => {
+  const items = new Map();
+  const linkItems = extractScratchersFromLinks(doc, baseUrl);
+  linkItems.forEach((item) => items.set(item.url, item));
+  const textItems = extractScratchersFromText(rawText, baseUrl);
+  textItems.forEach((item) => {
+    if (!items.has(item.url)) items.set(item.url, item);
+  });
+  return Array.from(items.values());
+};
+
 const renderScratchers = (scratchers) => {
   if (!scratchersBody) return;
   if (!scratchers.length) {
@@ -120,13 +369,48 @@ const renderScratchers = (scratchers) => {
         <td><a href="${escapeHtml(scratcher.url)}" target="_blank" rel="noreferrer">${escapeHtml(
         scratcher.name
       )}</a></td>
-        <td>—</td>
-        <td>—</td>
-        <td>—</td>
+        <td>${formatOdds(scratcher.claimedCashOdds)}</td>
+        <td>${formatOdds(scratcher.calculatedCashOdds)}</td>
+        <td>${formatCurrency(scratcher.claimedExpectedValue)}</td>
+        <td>${formatCurrency(scratcher.expectedValue)}</td>
+        <td>${renderEvDelta(scratcher.claimedExpectedValue, scratcher.expectedValue)}</td>
       </tr>`
     )
     .join('');
   scratchersBody.innerHTML = rows;
+};
+
+const renderEvDelta = (claimedValue, calculatedValue) => {
+  const claimed = Number(claimedValue);
+  const calculated = Number(calculatedValue);
+  if (!Number.isFinite(claimed) || !Number.isFinite(calculated) || claimed === 0) {
+    return '—';
+  }
+  const delta = calculated - claimed;
+  const percent = delta / Math.abs(claimed);
+  const color = evDeltaColor(percent);
+  const percentLabel = `${(percent * 100).toFixed(1)}%`;
+  return `<span style="display:inline-block;padding:0.1rem 0.35rem;border-radius:0.4rem;background:${color};color:#0d1b2a;">${percentLabel}</span>`;
+};
+
+const evDeltaColor = (percent) => {
+  const clamped = Math.max(-0.5, Math.min(0.5, percent));
+  const normalized = (clamped + 0.5) / 1;
+  const hue = normalized * 120;
+  return `hsl(${hue}, 65%, 80%)`;
+};
+
+const formatOdds = (value) => {
+  const odds = Number(value);
+  if (!Number.isFinite(odds) || odds <= 0) return '—';
+  return `1 in ${odds.toFixed(2)}`;
+};
+
+const formatCurrency = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return '—';
+  const formatted = Math.abs(numeric).toFixed(2);
+  return numeric < 0 ? `-$${formatted}` : `$${formatted}`;
 };
 
 const sortScratchers = (scratchers) =>
@@ -140,8 +424,36 @@ const sortScratchers = (scratchers) =>
 const loadScratchers = async () => {
   try {
     setStatus('Loading scratchers...');
-    const { doc } = await fetchScratchersDocument('https://www.calottery.com/en/scratchers');
-    const scratchers = sortScratchers(extractScratchersFromLinks(doc, window.location.href));
+    const sourceUrl = 'https://www.calottery.com/en/scratchers';
+    const { doc, rawText } = await fetchScratchersDocument(sourceUrl);
+    const baseUrl = new URL(sourceUrl).origin;
+    let scratchers = [];
+    try {
+      const apiResponse = await fetchViaProxies(
+        'https://www.calottery.com/api/games/scratchers',
+        'Fetching scratchers data'
+      );
+      const apiData = JSON.parse(apiResponse);
+      scratchers = parseScratchersFromGamesApi(apiData, baseUrl);
+    } catch (error) {
+      scratchers = [];
+    }
+    if (!scratchers.length) {
+      const apiUrl = findScratchersApiUrl(rawText, baseUrl);
+      if (apiUrl) {
+        try {
+          const apiResponse = await fetchViaProxies(apiUrl, 'Fetching scratchers data');
+          const apiData = JSON.parse(apiResponse);
+          scratchers = parseScratchersFromApiData(apiData, baseUrl);
+        } catch (error) {
+          scratchers = [];
+        }
+      }
+    }
+    if (!scratchers.length) {
+      scratchers = extractScratchers(doc, rawText, baseUrl);
+    }
+    scratchers = sortScratchers(scratchers);
     renderScratchers(scratchers);
     setStatus(`Loaded ${scratchers.length} scratchers.`);
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Provide a quick visual comparison between the Claimed Expected Value and the calculated (actual) expected value by adding a heatmap-style EV delta column to the scratchers table. 
- Improve robustness of scraping and API fetching by routing fetches through the proxy array and supporting more API/content formats.

### Description
- Updated `scratchers.html` to rename `Expected Value` to `Calculated Expected Value` and add a new `EV Delta` column. 
- Expanded `scratchers.js` with `fetchViaProxies`, `extractScratchersFromText`, `findScratchersApiUrl`, `parseScratchersFromGamesApi`, `parseScratchersFromApiData`, and `calculateStatsFromPrizeTiers` to support API discovery, parsing various response shapes, and computing odds/EVs. 
- Rendered claimed/calculated odds and EV values and added `renderEvDelta` plus `evDeltaColor` to compute percent delta and return a colorized HSL badge for the heatmap. 
- Added utility formatters `formatOdds` and `formatCurrency`, and updated `loadScratchers`/`extractScratchers` flows to use the new fetch/parsing pipeline and to preserve URL base origins when building resource URLs.

### Testing
- Served the site locally with `python -m http.server 8000` and ran a headless Playwright script to load `http://127.0.0.1:8000/scratchers.html` and capture a screenshot to `artifacts/scratchers-table.png`, which completed successfully. 
- Committed the changes locally (`git commit`), which reported the files changed and completed without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e1f54998832da6e3aec88cdcf1ec)